### PR TITLE
Support non 200 responses containing GraphQL data/errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes will be documented in this file. The format is based on [Kee
 
 ## Unreleased
 
+### Added
+
+- support for handling non 200 responses as regular GraphQL responses
+
 ## 1.1.0 - 2021-04-28
 
 ### Added


### PR DESCRIPTION
- invoke HTTP error handler when the deserialization fails or
there are no GraphQL fields (data or errors)
- added a test for the new use case
- updated documentation for `onHttpError`
- changed error prefix from `[GraphQL]` to `[fetch-gql]`
- updated changelog

closes #5 